### PR TITLE
Ajout yunohost.multimedia

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -58,3 +58,12 @@ sudo sed -i "s@<div id=\"toolbar-inspector\" title=\"Toggle Inspector\"></div>@<
 sed -i "s@PATHTOCHANGE@$path@g" ../conf/nginx.conf
 sudo cp ../conf/nginx.conf /etc/nginx/conf.d/$domain.d/$app.conf
 sudo service nginx reload
+
+# Add yunohost.multimedia directory
+wget https://github.com/maniackcrudelis/yunohost.multimedia/archive/master.zip
+unzip master.zip
+sudo ./yunohost.multimedia-master/script/ynh_media_build.sh
+# Set rights on transmission directory (parent need to be readable by other, and progress need to be writable by multimedia. Because files will move)
+sudo ./yunohost.multimedia-master/script/ynh_media_addfolder.sh --source="/home/yunohost.transmission" --dest="share/Torrents"
+# And share completed directory
+sudo ./yunohost.multimedia-master/script/ynh_media_addfolder.sh --source="/home/yunohost.transmission/completed" --dest="share/Torrents"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -43,3 +43,12 @@ fi
 sed -i "s@PATHTOCHANGE@$path@g" ../conf/nginx.conf
 sudo cp ../conf/nginx.conf /etc/nginx/conf.d/$domain.d/$app.conf
 sudo service nginx reload
+
+# Update yunohost.multimedia directory
+wget https://github.com/maniackcrudelis/yunohost.multimedia/archive/master.zip
+unzip master.zip
+sudo ./yunohost.multimedia-master/script/ynh_media_build.sh
+# Set rights on transmission directory (parent need to be readable by other, and progress need to be writable by multimedia. Because files will move)
+sudo ./yunohost.multimedia-master/script/ynh_media_addfolder.sh --source="/home/yunohost.transmission" --dest="share/Torrents"
+# And share completed directory
+sudo ./yunohost.multimedia-master/script/ynh_media_addfolder.sh --source="/home/yunohost.transmission/completed" --dest="share/Torrents"


### PR DESCRIPTION
Intégration de la prise en charge du dossier yunohost.multimedia

Création (ou mise à jour) des dossiers multimédias et partage du dossier completed pour rendre accessible les torrents téléchargés.

Afin que le dossier completed soit accessible en lecture par les utilisateurs et les applications dans le dossier multimédia, le dossier parent /home/yunohost.transmission doit être accessible en lecture par other.
De plus, les fichiers téléchargés étant déplacés dans le dossier completed, les droits sur les fichiers doivent s'appliquer dés le dossier progress.
C'est pour cette raison que le dossier /home/yunohost.transmission est d'abord partagé, afin de lui appliquer les droits, puis remplacé par le dossier completed. Seul ce dernier dossier sera finalement accessible depuis le dossier multimédia.
