### PR TITLE
Add support for RPC password and watchdir

### DIFF
--- a/conf/settings.json
+++ b/conf/settings.json
@@ -45,7 +45,7 @@
     "rpc-authentication-required": false,
     "rpc-bind-address": "127.0.0.1", 
     "rpc-enabled": true,
-    "rpc-password": "{22ef1abe361f619946cf9ce68c442d27f73512d5lL3qJ6bY",
+    "rpc-password": "RPCPASSWORDTOCHANGE",
     "rpc-port": 9091,
     "rpc-url": "PATHTOCHANGE/transmission/",
     "rpc-username": "transmission",

--- a/conf/settings.json
+++ b/conf/settings.json
@@ -66,5 +66,7 @@
     "upload-limit": 100,
     "upload-limit-enabled": 0,
     "upload-slots-per-torrent": 14,
-    "utp-enabled": true
+    "utp-enabled": true,
+    "watch-dir": "/home/yunohost.transmission/watched",
+    "watch-dir-enabled": true
 }

--- a/scripts/install
+++ b/scripts/install
@@ -46,6 +46,15 @@ sudo find /home/yunohost.transmission/ -type d | while read LINE; do sudo chmod 
 sudo find /home/yunohost.transmission/watched -type d | while read LINE; do sudo chmod 770 "$LINE" ; done
 ynh_app_setting_set "$app" watchdir "/home/yunohost.transmission/watched"
 
+# YunoHost multimedia
+wget -qq https://github.com/YunoHost-Apps/yunohost.multimedia/archive/master.zip
+unzip -qq master.zip
+sudo ./yunohost.multimedia-master/script/ynh_media_build.sh
+# Set rights on transmission directory (parent need to be readable by other, and progress need to be writable by multimedia. Because files will move)
+sudo ./yunohost.multimedia-master/script/ynh_media_addfolder.sh --source="/home/yunohost.transmission" --dest="share/Torrents"
+# And share completed directory
+sudo ./yunohost.multimedia-master/script/ynh_media_addfolder.sh --source="/home/yunohost.transmission/completed" --dest="share/Torrents"
+
 # Create RPC password
 rpcpassword=$(ynh_string_random)
 ynh_app_setting_set "$app" rpcpassword "$rpcpassword"

--- a/scripts/install
+++ b/scripts/install
@@ -6,6 +6,9 @@ set -eu
 # Get app instance name
 app=$YNH_APP_INSTANCE_NAME
 
+# Source app helpers
+. /usr/share/yunohost/helpers
+
 # Retrieve arguments
 domain=$YNH_APP_ARG_DOMAIN
 path=$YNH_APP_ARG_PATH
@@ -41,7 +44,12 @@ sudo chown -R debian-transmission:debian-transmission /home/yunohost.transmissio
 sudo find /home/yunohost.transmission/ -type f | while read LINE; do sudo chmod 640 "$LINE" ; done
 sudo find /home/yunohost.transmission/ -type d | while read LINE; do sudo chmod 750 "$LINE" ; done
 
+# Create RPC password
+rpcpassword=$(ynh_string_random)
+ynh_app_setting_set "$app" rpcpassword "$rpcpassword"
+
 # Configure Transmission and reload
+sed -i "s@RPCPASSWORDTOCHANGE@$rpcpassword@g" ../conf/settings.json
 sed -i "s@PATHTOCHANGE@$path@g" ../conf/settings.json
 sudo cp ../conf/settings.json /etc/transmission-daemon/settings.json
 sudo service transmission-daemon reload

--- a/scripts/install
+++ b/scripts/install
@@ -38,21 +38,24 @@ sudo yunohost firewall allow TCP 51413 > /dev/null 2>&1
 sudo apt-get install transmission-daemon -y -qq
 
 # Make directories and set rights
-sudo mkdir -p /home/yunohost.transmission/{progress,completed}
+sudo mkdir -p /home/yunohost.transmission/{progress,completed,watched}
 sudo chown -R debian-transmission:www-data /home/yunohost.transmission/
-sudo chown -R debian-transmission:debian-transmission /home/yunohost.transmission/progress
+sudo chown -R debian-transmission:debian-transmission /home/yunohost.transmission/progress /home/yunohost.transmission/watched
 sudo find /home/yunohost.transmission/ -type f | while read LINE; do sudo chmod 640 "$LINE" ; done
 sudo find /home/yunohost.transmission/ -type d | while read LINE; do sudo chmod 750 "$LINE" ; done
+sudo find /home/yunohost.transmission/watched -type d | while read LINE; do sudo chmod 770 "$LINE" ; done
+ynh_app_setting_set "$app" watchdir "/home/yunohost.transmission/watched"
 
 # Create RPC password
 rpcpassword=$(ynh_string_random)
 ynh_app_setting_set "$app" rpcpassword "$rpcpassword"
 
 # Configure Transmission and reload
+sudo service transmission-daemon stop
 sed -i "s@RPCPASSWORDTOCHANGE@$rpcpassword@g" ../conf/settings.json
 sed -i "s@PATHTOCHANGE@$path@g" ../conf/settings.json
 sudo cp ../conf/settings.json /etc/transmission-daemon/settings.json
-sudo service transmission-daemon reload
+sudo service transmission-daemon start
 
 # Monitor service
 sudo yunohost service add transmission-daemon

--- a/scripts/restore
+++ b/scripts/restore
@@ -53,11 +53,12 @@ sudo yunohost firewall allow TCP 51413 > /dev/null 2>&1
 sudo apt-get install transmission-daemon -y -qq
 
 # Make directories and set rights
-sudo mkdir -p /home/yunohost.transmission/{progress,completed}
+sudo mkdir -p /home/yunohost.transmission/{progress,completed,watched}
 sudo chown -R debian-transmission:www-data /home/yunohost.transmission/
-sudo chown -R debian-transmission:debian-transmission /home/yunohost.transmission/progress
+sudo chown -R debian-transmission:debian-transmission /home/yunohost.transmission/progress /home/yunohost.transmission/watched
 sudo find /home/yunohost.transmission/ -type f | while read LINE; do sudo chmod 640 "$LINE" ; done
 sudo find /home/yunohost.transmission/ -type d | while read LINE; do sudo chmod 750 "$LINE" ; done
+sudo find /home/yunohost.transmission/watched -type d | while read LINE; do sudo chmod 770 "$LINE" ; done
 
 # Reload transmission service
 sudo service transmission-daemon reload

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -6,9 +6,13 @@ set -eu
 # Get app instance name
 app=$YNH_APP_INSTANCE_NAME
 
+# Source app helpers
+. /usr/share/yunohost/helpers
+
 # Retrieve arguments
-domain=$(sudo yunohost app setting "$app" domain)
-path=$(sudo yunohost app setting "$app" path)
+domain=$(ynh_app_setting_get "$app" domain)
+path=$(ynh_app_setting_get "$app" path)
+rpcpassword=$(ynh_app_setting_get "$app" rpcpassword)
 
 # Remove trailing "/" for next commands
 path=${path%/}
@@ -26,7 +30,14 @@ sudo chown -R debian-transmission:debian-transmission /home/yunohost.transmissio
 sudo find /home/yunohost.transmission/ -type f | while read LINE; do sudo chmod 640 "$LINE" ; done
 sudo find /home/yunohost.transmission/ -type d | while read LINE; do sudo chmod 750 "$LINE" ; done
 
+# Create RPC password if none exists
+if [ -z "$rpcpassword" ]; then
+    rpcpassword=$(ynh_string_random)
+	ynh_app_setting_set "$app" rpcpassword "$rpcpassword"
+fi
+
 # Configure Transmission and reload
+sed -i "s@RPCPASSWORDTOCHANGE@$rpcpassword@g" ../conf/settings.json
 sed -i "s@PATHTOCHANGE@$path@g" ../conf/settings.json
 sudo cp ../conf/settings.json /etc/transmission-daemon/settings.json
 sudo service transmission-daemon reload

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -13,6 +13,7 @@ app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get "$app" domain)
 path=$(ynh_app_setting_get "$app" path)
 rpcpassword=$(ynh_app_setting_get "$app" rpcpassword)
+watchdir=$(ynh_app_setting_get "$app" watchdir)
 
 # Remove trailing "/" for next commands
 path=${path%/}
@@ -24,11 +25,16 @@ sudo yunohost firewall allow TCP 51413 > /dev/null 2>&1
 sudo apt-get install transmission-daemon -y -qq
 
 # Make directories and set rights
-sudo mkdir -p /home/yunohost.transmission/{progress,completed}
+sudo mkdir -p /home/yunohost.transmission/{progress,completed,watched}
 sudo chown -R debian-transmission:www-data /home/yunohost.transmission/
-sudo chown -R debian-transmission:debian-transmission /home/yunohost.transmission/progress
+sudo chown -R debian-transmission:debian-transmission /home/yunohost.transmission/progress /home/yunohost.transmission/watched
 sudo find /home/yunohost.transmission/ -type f | while read LINE; do sudo chmod 640 "$LINE" ; done
 sudo find /home/yunohost.transmission/ -type d | while read LINE; do sudo chmod 750 "$LINE" ; done
+sudo find /home/yunohost.transmission/watched -type d | while read LINE; do sudo chmod 770 "$LINE" ; done
+# Add watchdir in settings if it does not exist yet (previous versions)
+if [ -z "$watchdir" ]; then
+    ynh_app_setting_set "$app" watchdir "/home/yunohost.transmission/watched"
+fi
 
 # Create RPC password if none exists
 if [ -z "$rpcpassword" ]; then
@@ -37,10 +43,11 @@ if [ -z "$rpcpassword" ]; then
 fi
 
 # Configure Transmission and reload
+sudo service transmission-daemon stop
 sed -i "s@RPCPASSWORDTOCHANGE@$rpcpassword@g" ../conf/settings.json
 sed -i "s@PATHTOCHANGE@$path@g" ../conf/settings.json
 sudo cp ../conf/settings.json /etc/transmission-daemon/settings.json
-sudo service transmission-daemon reload
+sudo service transmission-daemon start
 
 # Patch sources to add a download button
 if ! grep 'toolbar-downloads' /usr/share/transmission/web/index.html --quiet; then

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -36,6 +36,15 @@ if [ -z "$watchdir" ]; then
     ynh_app_setting_set "$app" watchdir "/home/yunohost.transmission/watched"
 fi
 
+# YunoHost multimedia
+wget -qq https://github.com/YunoHost-Apps/yunohost.multimedia/archive/master.zip
+unzip -qq master.zip
+sudo ./yunohost.multimedia-master/script/ynh_media_build.sh
+# Set rights on transmission directory (parent need to be readable by other, and progress need to be writable by multimedia. Because files will move)
+sudo ./yunohost.multimedia-master/script/ynh_media_addfolder.sh --source="/home/yunohost.transmission" --dest="share/Torrents"
+# And share completed directory
+sudo ./yunohost.multimedia-master/script/ynh_media_addfolder.sh --source="/home/yunohost.transmission/completed" --dest="share/Torrents"
+
 # Create RPC password if none exists
 if [ -z "$rpcpassword" ]; then
     rpcpassword=$(ynh_string_random)


### PR DESCRIPTION
These commits:
- Generates a RPC password and adds it in settings (so that Transmission can be accessed by other apps through RPC)
- Creates a watchdir and adds it in settings (so that other apps or users can use it)