### PR TITLE
Fix permission on home/yunohost.transmission

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -77,7 +77,7 @@ mkdir -p /home/yunohost.transmission/{progress,completed,watched}
 
 chown -R debian-transmission:www-data /home/yunohost.transmission/
 chown -R debian-transmission: /home/yunohost.transmission/{progress,watched}
-chmod -R 640 /home/yunohost.transmission
+chmod -R 764 /home/yunohost.transmission
 chmod -R 777 /home/yunohost.transmission/watched
 
 #=================================================


### PR DESCRIPTION
## Problem
- *"Transmission was unable to add new files in the completed location because /home/yunohost.transmission was missing 'x' permission for owner"*

## Solution
- *Fix bad permissions in upgrade script*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : JimboJoe
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : 
- [x] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/transmission_ynh%20fix_permission%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/transmission_ynh%20fix_permission%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.