### PR TITLE
Add rpc-host-whitelist

### DIFF
--- a/conf/settings.json
+++ b/conf/settings.json
@@ -46,6 +46,8 @@
     "rpc-authentication-required": false, 
     "rpc-bind-address": "127.0.0.1", 
     "rpc-enabled": true, 
+    "rpc-host-whitelist": "", 
+    "rpc-host-whitelist-enabled": true, 
     "rpc-password": "__RPC_PASSWORD_TO_CHANGE__", 
     "rpc-port": __PORT__, 
     "rpc-url": "__PATH__transmission/", 


### PR DESCRIPTION
## Problem
- *Fix https://github.com/YunoHost-Apps/transmission_ynh/issues/47*
I don't reproduce the error though...

## Solution
- *Add the missing options*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/transmission_ynh%20add-rpc-host-whitelist%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/transmission_ynh%20add-rpc-host-whitelist%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
