### PR TITLE
Detect issue related to transmission-common and reinstall it if needed

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -66,7 +66,7 @@ ynh_app_setting_set $app peer_port $peer_port
 # INSTALL TRANSMISSION
 #=================================================
 
-ynh_install_app_dependencies transmission-daemon acl
+ynh_install_app_dependencies transmission-daemon transmission-cli transmission-common acl
 
 # Fix a stupid issue which happens sometimes ...
 # transmission-common is installed (it's a dependency of

--- a/scripts/install
+++ b/scripts/install
@@ -68,6 +68,17 @@ ynh_app_setting_set $app peer_port $peer_port
 
 ynh_install_app_dependencies transmission-daemon acl
 
+# Fix a stupid issue which happens sometimes ...
+# transmission-common is installed (it's a dependency of
+# transmission-daemon) but somehow the files it's supposed
+# to add ain't there ... and possibly also the transmission user
+# is missing.
+# Explicitly reinstalling the package fixes the issue :|
+if [ ! -d /usr/share/transmission/ ]
+then
+   ynh_package_install transmission-common --reinstall
+fi
+
 #=================================================
 # NGINX CONFIGURATION
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -60,7 +60,7 @@ yunohost firewall allow Both $peer_port >/dev/null 2>&1
 # REINSTALL TRANSMISSION
 #=================================================
 
-ynh_install_app_dependencies transmission-daemon acl
+ynh_install_app_dependencies transmission-daemon transmission-cli transmission-common acl
 
 #=================================================
 # RESTORE TRANSMISSION CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -70,7 +70,7 @@ ynh_add_nginx_config
 # INSTALL DEPENDENCIES
 #=================================================
 
-ynh_install_app_dependencies transmission-daemon acl
+ynh_install_app_dependencies transmission-daemon transmission-cli transmission-common acl
 
 #=================================================
 # SPECIFIC UPGRADE


### PR DESCRIPTION
## Problem

 c.f. https://github.com/YunoHost-Apps/transmission_ynh/issues/44 which is a fucking crazy issue where `transmission-daemon` and `transmission-common` were installed, but somehow the transmission user was not there, nor the `/usr/share/transmission` files :sweat: 

I think this was at least the 3rd time I saw this issue happen ...

## Solution

Was finally able to fix the issue by running `apt install transmission-common --reinstall` :sweat: 

Made this YOLO PR, not really tested...

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/transmission_ynh%20PR52/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/transmission_ynh%20PR52/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
