### PR TITLE
Fix backup backup core only

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         	"email": "apps@yunohost.org"
 	},
 	"requirements": {
-		"yunohost": ">= 2.7.2"
+		"yunohost": ">= 3.2"
 	},
 	"multi_instance": false,
 	"services": [

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 		"en": "A Fast, Easy, and Free BitTorrent Client",
 		"fr": "Un client BitTorrent libre et rapide"
 	},
-	"version": "1.0",
+	"version": "1.0~ynh1",
 	"url": "https://www.transmissionbt.com/",
 	"license": " GPL-3.0",
 	"maintainer": {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -13,25 +13,3 @@ ynh_multimedia_build_main_dir () {
 ynh_multimedia_addfolder () {
 	./yunohost.multimedia-master/script/ynh_media_addfolder.sh --source="$1" --dest="$2"
 }
-
-#=================================================
-# BACKUP
-#=================================================
-
-HUMAN_SIZE () {	# Transforme une taille en Ko en une taille lisible pour un humain
-	human=$(numfmt --to=iec --from-unit=1K $1)
-	echo $human
-}
-
-CHECK_SIZE () {	# Vérifie avant chaque backup que l'espace est suffisant
-	file_to_analyse=$1
-	backup_size=$(du --summarize "$file_to_analyse" | cut -f1)
-	free_space=$(df --output=avail "/home/yunohost.backup" | sed 1d)
-
-	if [ $free_space -le $backup_size ]
-	then
-		echo "Espace insuffisant pour sauvegarder $file_to_analyse." >&2
-		echo "Espace disponible: $(HUMAN_SIZE $free_space)" >&2
-		ynh_die "Espace nécessaire: $(HUMAN_SIZE $backup_size)"
-	fi
-}

--- a/scripts/backup
+++ b/scripts/backup
@@ -50,10 +50,8 @@ ynh_backup "/etc/transmission-daemon/settings.json"
 #=================================================
 
 ynh_backup "/usr/share/transmission"
-
 ynh_backup "/var/lib/transmission-daemon"
 
-CHECK_SIZE "/home/yunohost.transmission"
 # The "--is big" parameter indicates that the file/directory requires "a lot of disk space"
 # It won't be backed up before 'upgrade' or while doing a 'backup' with:
 # "sudo BACKUP_CORE_ONLY=1 yunohost backup create --apps transmission"

--- a/scripts/backup
+++ b/scripts/backup
@@ -56,6 +56,6 @@ ynh_backup "/var/lib/transmission-daemon"
 CHECK_SIZE "/home/yunohost.transmission"
 # The "--is big" parameter indicates that the file/directory requires "a lot of disk space"
 # It won't be backed up before 'upgrade' or while doing a 'backup' with:
-# "sudo BACKUP_CORE_ONLY=1 yunohost backup create --apps nextcloud"
+# "sudo BACKUP_CORE_ONLY=1 yunohost backup create --apps transmission"
 # See https://yunohost.org/#/backup
-ynh_backup "/home/yunohost.transmission" --is_big
+ynh_backup --src_path="/home/yunohost.transmission" --is_big

--- a/scripts/backup
+++ b/scripts/backup
@@ -53,12 +53,9 @@ ynh_backup "/usr/share/transmission"
 
 ynh_backup "/var/lib/transmission-daemon"
 
-backup_core_only=$(ynh_app_setting_get $app backup_core_only)
-# If backup_core_only have a value in settings.yml, do not backup the data directory
-if [ -z $backup_core_only ]
-then
-	CHECK_SIZE "/home/yunohost.transmission"
-	ynh_backup "/home/yunohost.transmission"
-else
-	echo "Data dir will not saved, because backup_core_only is set." >&2
-fi
+CHECK_SIZE "/home/yunohost.transmission"
+# The "--is big" parameter indicates that the file/directory requires "a lot of disk space"
+# It won't be backed up before 'upgrade' or while doing a 'backup' with:
+# "sudo BACKUP_CORE_ONLY=1 yunohost backup create --apps nextcloud"
+# See https://yunohost.org/#/backup
+ynh_backup "/home/yunohost.transmission" --is_big

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -156,7 +156,7 @@ systemctl reload nginx
 backup_core_only=$(ynh_app_setting_get $app backup_core_only)
 # If "backup_core_only" is still set in settings.yml, print a warning and run the upgrade as usual.
 # Setting is deleted at the end of the script to avoid side effect ("ynh_backup_before_upgrade" maybe).
-if [ -z $backup_core_only ]
+if [ "$backup_core_only" == "1" ]
 then
 	ynh_print_info --message="Setting 'backup_core_only' is deprecated and cannot be used anymore"
 	ynh_print_info --message="Modify your backup script accordingly or next backup will be huge. See https://github.com/YunoHost/doc/blob/master/backup.md#apps-specific-configuration"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -40,8 +40,6 @@ yunohost firewall allow UDP $peer_port >/dev/null 2>&1
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================
 
-# Inform the backup/restore process that it should not save the data directory
-ynh_app_setting_set $app backup_core_only 1
 ynh_backup_before_upgrade	# Backup the current version of the app
 ynh_clean_setup () {
 	ynh_restore_upgradebackup	# restore it if the upgrade fails
@@ -155,4 +153,16 @@ systemctl reload nginx
 # REMOVE BACKUP_CORE_ONLY
 #=================================================
 
+backup_core_only=$(ynh_app_setting_get $app backup_core_only)
+# If "backup_core_only" is still set in settings.yml, print a warning and run the upgrade as usual.
+# Setting is deleted at the end of the script to avoid side effect ("ynh_backup_before_upgrade" maybe).
+if [ -z $backup_core_only ]
+then
+	ynh_print_info --message="Setting 'backup_core_only' is deprecated and cannot be used anymore"
+	ynh_print_info --message="Modify your backup script accordingly or next backup will be huge. See https://github.com/YunoHost/doc/blob/master/backup.md#apps-specific-configuration"
+fi
+
+# Remove deprecated option "backup_core_only" if it's in the settings.yml file.
+# Replaced by "environement variable" => sudo BACKUP_CORE_ONLY=1 yunohost backup create [...]
+# See https://yunohost.org/#/backup.
 ynh_app_setting_delete $app backup_core_only


### PR DESCRIPTION
## Problem
- Backup size was huge after recent upgrade. Even after using `BACKUP_CORE_ONLY` flag

## Solution
- Modify backup script to handle `BACKUP_CORE_ONLY` flag

## Infos

I don't really know how to manage `backup_core_only` so I am not sure the first upgrade will work (master => PR branch)

Has been quickly tested in a VM (cannot run `Package_check`)

- Upgrade master branch to this PR : OK
- Install this PR and then upgrade : OK

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [X] Fix or enhancement tested.
- [X] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/transmission_ynh%20PR54/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/transmission_ynh%20PR54/) 

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.