### PR TITLE
Fix warning

### DIFF
--- a/conf/90-transmission.conf
+++ b/conf/90-transmission.conf
@@ -1,0 +1,2 @@
+net.core.rmem_max = 4194304
+net.core.wmem_max = 1048576

--- a/conf/90-transmission.conf
+++ b/conf/90-transmission.conf
@@ -1,2 +1,5 @@
+# These settings affect the size of the buffers for send and receive sockets.
+# Size of receive socket buffer
 net.core.rmem_max = 4194304
+# Size of send socket buffer
 net.core.wmem_max = 1048576

--- a/scripts/backup
+++ b/scripts/backup
@@ -42,6 +42,7 @@ ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_script_progression --message="Backing up transmission configuration..."
 
 ynh_backup --src_path="/etc/transmission-daemon/settings.json"
+ynh_backup --src_path="/etc/sysctl.d/90-transmission.conf"
 
 #=================================================
 # BACKUP DATA

--- a/scripts/install
+++ b/scripts/install
@@ -131,7 +131,7 @@ cp ../conf/settings.json /etc/transmission-daemon/settings.json
 
 cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
 if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
-    sysctl --system
+    sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -130,7 +130,9 @@ ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_f
 cp ../conf/settings.json /etc/transmission-daemon/settings.json
 
 cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
-sysctl --system
+if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
+    sysctl --system
+fi
 
 #=================================================
 # STORE THE CHECKSUM OF THE CONFIG FILE

--- a/scripts/install
+++ b/scripts/install
@@ -118,7 +118,6 @@ ynh_systemd_action --service_name=transmission-daemon --action=stop
 rpcpassword=$(ynh_string_random)
 ynh_app_setting_set --app=$app --key=rpcpassword --value="$rpcpassword"
 
-
 ynh_replace_string --match_string="__RPC_PASSWORD_TO_CHANGE__" --replace_string="$rpcpassword" --target_file=../conf/settings.json
 if [ "$path_url" != "/" ]
 then
@@ -130,11 +129,15 @@ ynh_replace_string --match_string="__PEER_PORT__" --replace_string="$peer_port" 
 ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file=../conf/settings.json
 cp ../conf/settings.json /etc/transmission-daemon/settings.json
 
+cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
+sysctl --system
+
 #=================================================
 # STORE THE CHECKSUM OF THE CONFIG FILE
 #=================================================
 
 ynh_store_file_checksum --file=/etc/transmission-daemon/settings.json
+ynh_store_file_checksum --file=/etc/sysctl.d/90-transmission.conf
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION

--- a/scripts/remove
+++ b/scripts/remove
@@ -75,6 +75,9 @@ ynh_script_progression --message="Removing transmission data..."
 ynh_secure_remove --file=/usr/share/transmission
 # And data
 ynh_secure_remove --file=/var/lib/transmission-daemon
+# Kernel parameters
+ynh_secure_remove --file=/etc/sysctl.d/90-transmission.conf
+sysctl --system
 
 #=================================================
 # GENERIC FINALISATION

--- a/scripts/remove
+++ b/scripts/remove
@@ -78,7 +78,7 @@ ynh_secure_remove --file=/var/lib/transmission-daemon
 # Kernel parameters
 ynh_secure_remove --file=/etc/sysctl.d/90-transmission.conf
 if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
-    sysctl --system
+    sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -77,7 +77,9 @@ ynh_secure_remove --file=/usr/share/transmission
 ynh_secure_remove --file=/var/lib/transmission-daemon
 # Kernel parameters
 ynh_secure_remove --file=/etc/sysctl.d/90-transmission.conf
-sysctl --system
+if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
+    sysctl --system
+fi
 
 #=================================================
 # GENERIC FINALISATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -73,7 +73,7 @@ ynh_systemd_action --service_name=transmission-daemon --action=stop
 ynh_secure_remove --file=/etc/transmission-daemon/settings.json
 ynh_restore_file --origin_path=/etc/transmission-daemon/settings.json
 
-ynh_restore_file --src_path="/etc/sysctl.d/90-transmission.conf"
+ynh_restore_file --origin_path="/etc/sysctl.d/90-transmission.conf"
 if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
     sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi

--- a/scripts/restore
+++ b/scripts/restore
@@ -74,7 +74,9 @@ ynh_secure_remove --file=/etc/transmission-daemon/settings.json
 ynh_restore_file --origin_path=/etc/transmission-daemon/settings.json
 
 ynh_restore_file --src_path="/etc/sysctl.d/90-transmission.conf"
-sysctl --system
+if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
+    sysctl --system
+fi
 
 #=================================================
 # RESTORE DATA

--- a/scripts/restore
+++ b/scripts/restore
@@ -73,6 +73,9 @@ ynh_systemd_action --service_name=transmission-daemon --action=stop
 ynh_secure_remove --file=/etc/transmission-daemon/settings.json
 ynh_restore_file --origin_path=/etc/transmission-daemon/settings.json
 
+ynh_restore_file --src_path="/etc/sysctl.d/90-transmission.conf"
+sysctl --system
+
 #=================================================
 # RESTORE DATA
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -75,7 +75,7 @@ ynh_restore_file --origin_path=/etc/transmission-daemon/settings.json
 
 ynh_restore_file --src_path="/etc/sysctl.d/90-transmission.conf"
 if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
-    sysctl --system
+    sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -134,12 +134,19 @@ ynh_replace_string --match_string="__PEER_PORT__" --replace_string="$peer_port" 
 ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file=../conf/settings.json
 cp ../conf/settings.json /etc/transmission-daemon/settings.json
 
+# Verify the checksum and backup the file if it's different
+ynh_backup_if_checksum_is_different --file=/etc/sysctl.d/90-transmission.conf
+
+cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
+sysctl --system
+
 #=================================================
 # STORE THE CHECKSUM OF THE CONFIG FILE
 #=================================================
 
 # Recalculate and store the config file checksum into the app settings
 ynh_store_file_checksum --file=/etc/transmission-daemon/settings.json
+ynh_store_file_checksum --file=/etc/sysctl.d/90-transmission.conf
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -139,7 +139,7 @@ ynh_backup_if_checksum_is_different --file=/etc/sysctl.d/90-transmission.conf
 
 cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
 if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
-    sysctl --system
+    sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -138,7 +138,9 @@ cp ../conf/settings.json /etc/transmission-daemon/settings.json
 ynh_backup_if_checksum_is_different --file=/etc/sysctl.d/90-transmission.conf
 
 cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
-sysctl --system
+if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
+    sysctl --system
+fi
 
 #=================================================
 # STORE THE CHECKSUM OF THE CONFIG FILE


### PR DESCRIPTION
## Problem
- Warnings in log:
```
error UDP Failed to set receive buffer: requested 4194304, got 425984
UDP Please add the line "net.core.rmem_max = 4194304" to /etc/sysctl.conf
error UDP Failed to set send buffer: requested 1048576, got 425984
UDP Please add the line "net.core.wmem_max = 1048576" to /etc/sysctl.conf
```

## Solution
- Update the kernel parameters.

**This may fail with the CI, because LXC doesn't want to change the kernel parameters.**

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/transmission_ynh%20PR58/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/transmission_ynh%20PR58/)  

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
