### PR TITLE
Move code to avoid a warning during the remove

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -23,13 +23,6 @@ peer_port=$(ynh_app_setting_get --app=$app --key=peer_port)
 #=================================================
 # STANDARD REMOVE
 #=================================================
-# REMOVE TRANSMISSION-DAEMON
-#=================================================
-ynh_script_progression --message="Removing transmission..." --weight=9
-
-ynh_remove_app_dependencies
-
-#=================================================
 # REMOVE SERVICE FROM ADMIN PANEL
 #=================================================
 
@@ -39,6 +32,13 @@ then
 	ynh_script_progression --message="Removing $app service..." --weight=8
 	yunohost service remove transmission-daemon
 fi
+
+#=================================================
+# REMOVE TRANSMISSION-DAEMON
+#=================================================
+ynh_script_progression --message="Removing transmission..." --weight=9
+
+ynh_remove_app_dependencies
 
 #=================================================
 # CLOSE THE PORTS


### PR DESCRIPTION
## Problem
- *During the remove: *
```
Error: yunohost.service service_status - [1717.1] Failed to get status information via dbus for service transmission-daemon, systemctl didn't recognize this service ('NoSuchUnit').
```

## Solution
- *Remove the service before removing the dependencies*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/transmission_ynh%20PR62/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/transmission_ynh%20PR62/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
