### PR TITLE
Fix install in LXC because of missing /proc/sys/net/core/rmem_max

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -130,7 +130,7 @@ ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_f
 cp ../conf/settings.json /etc/transmission-daemon/settings.json
 
 cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
-if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
+if [ -e /proc/sys/net/core/rmem_max ]; then
     sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -74,7 +74,7 @@ ynh_secure_remove --file=/etc/transmission-daemon/settings.json
 ynh_restore_file --origin_path=/etc/transmission-daemon/settings.json
 
 ynh_restore_file --origin_path="/etc/sysctl.d/90-transmission.conf"
-if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
+if [ -e /proc/sys/net/core/rmem_max ]; then
     sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -138,7 +138,7 @@ cp ../conf/settings.json /etc/transmission-daemon/settings.json
 ynh_backup_if_checksum_is_different --file=/etc/sysctl.d/90-transmission.conf
 
 cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
-if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
+if [ -e /proc/sys/net/core/rmem_max ]; then
     sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 


### PR DESCRIPTION
## Problem

Testing the install on Buster, the install fails because it tried the `sysctl --load` ... thing, but /proc/sys/net/core/rmem_max doesn't exist on LXC. 

This thing was added in [this PR](https://github.com/YunoHost-Apps/transmission_ynh/pull/58) with the statement that "This may fail with the CI, because LXC doesn't want to change the kernel parameters.", thus the line was disabled for tests on the CI ...

Nevertheless, a Yunohost install in a LXC is a perferctly legitimate setup and we shouldn't block the install of Transmission in such case

## Solution

Test directly the existence of /proc/sys/net/core/rmem_max to trigger (or not) the `sysctl --load`). One could also rely on `systemd-detect-virt` to detect if we're in a lxc, but there might be other container technologies in which the issue arise and it's tricky to know and list all of these apriori.

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/transmission_ynh%20PR66/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/transmission_ynh%20PR66/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.