### PR TITLE
Do not use sysctl.d into LXC

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -42,7 +42,10 @@ ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_script_progression --message="Backing up transmission configuration..."
 
 ynh_backup --src_path="/etc/transmission-daemon/settings.json"
-ynh_backup --src_path="/etc/sysctl.d/90-transmission.conf"
+if [ -e /proc/sys/net/core/rmem_max ]
+then
+    ynh_backup --src_path="/etc/sysctl.d/90-transmission.conf"
+fi
 
 #=================================================
 # BACKUP DATA

--- a/scripts/install
+++ b/scripts/install
@@ -129,8 +129,9 @@ ynh_replace_string --match_string="__PEER_PORT__" --replace_string="$peer_port" 
 ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file=../conf/settings.json
 cp ../conf/settings.json /etc/transmission-daemon/settings.json
 
-cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
-if [ -e /proc/sys/net/core/rmem_max ]; then
+if [ -e /proc/sys/net/core/rmem_max ]
+then
+    cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
     sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 
@@ -139,7 +140,10 @@ fi
 #=================================================
 
 ynh_store_file_checksum --file=/etc/transmission-daemon/settings.json
-ynh_store_file_checksum --file=/etc/sysctl.d/90-transmission.conf
+if [ -e /proc/sys/net/core/rmem_max ]
+then
+    ynh_store_file_checksum --file=/etc/sysctl.d/90-transmission.conf
+fi
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION

--- a/scripts/remove
+++ b/scripts/remove
@@ -76,8 +76,9 @@ ynh_secure_remove --file=/usr/share/transmission
 # And data
 ynh_secure_remove --file=/var/lib/transmission-daemon
 # Kernel parameters
-ynh_secure_remove --file=/etc/sysctl.d/90-transmission.conf
-if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]; then
+if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]
+then
+    ynh_secure_remove --file=/etc/sysctl.d/90-transmission.conf
     sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -76,7 +76,7 @@ ynh_secure_remove --file=/usr/share/transmission
 # And data
 ynh_secure_remove --file=/var/lib/transmission-daemon
 # Kernel parameters
-if [ ${PACKAGE_CHECK_EXEC:-0} -eq 0 ]
+if [ -e /proc/sys/net/core/rmem_max ]
 then
     ynh_secure_remove --file=/etc/sysctl.d/90-transmission.conf
     sysctl --load=/etc/sysctl.d/90-transmission.conf

--- a/scripts/restore
+++ b/scripts/restore
@@ -73,8 +73,9 @@ ynh_systemd_action --service_name=transmission-daemon --action=stop
 ynh_secure_remove --file=/etc/transmission-daemon/settings.json
 ynh_restore_file --origin_path=/etc/transmission-daemon/settings.json
 
-ynh_restore_file --origin_path="/etc/sysctl.d/90-transmission.conf"
-if [ -e /proc/sys/net/core/rmem_max ]; then
+if [ -e /proc/sys/net/core/rmem_max ]
+then
+    ynh_restore_file --origin_path="/etc/sysctl.d/90-transmission.conf"
     sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -134,11 +134,12 @@ ynh_replace_string --match_string="__PEER_PORT__" --replace_string="$peer_port" 
 ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file=../conf/settings.json
 cp ../conf/settings.json /etc/transmission-daemon/settings.json
 
-# Verify the checksum and backup the file if it's different
-ynh_backup_if_checksum_is_different --file=/etc/sysctl.d/90-transmission.conf
+if [ -e /proc/sys/net/core/rmem_max ]
+then
+    # Verify the checksum and backup the file if it's different
+    ynh_backup_if_checksum_is_different --file=/etc/sysctl.d/90-transmission.conf
 
-cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
-if [ -e /proc/sys/net/core/rmem_max ]; then
+    cp ../conf/90-transmission.conf /etc/sysctl.d/90-transmission.conf
     sysctl --load=/etc/sysctl.d/90-transmission.conf
 fi
 
@@ -148,7 +149,10 @@ fi
 
 # Recalculate and store the config file checksum into the app settings
 ynh_store_file_checksum --file=/etc/transmission-daemon/settings.json
-ynh_store_file_checksum --file=/etc/sysctl.d/90-transmission.conf
+if [ -e /proc/sys/net/core/rmem_max ]
+then
+    ynh_store_file_checksum --file=/etc/sysctl.d/90-transmission.conf
+fi
 
 #=================================================
 # YUNOHOST MULTIMEDIA INTEGRATION


### PR DESCRIPTION
## Problem
- *The man of sysctl.d is quite clear: "Configure kernel parameters at boot"*

## Solution
- *Copy the conf file into /etc/sysctl.d only if not into a LXC*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/transmission_ynh%20PR68/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/transmission_ynh%20PR68/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.