### PR TITLE
Fix upgrade script for old versions

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -79,6 +79,11 @@ fi
 #=================================================
 ynh_script_progression --message="Adding multimedia directories..." --weight=3
 
+# Remove possibly dangling symlinks created before the /home/yunohost.transmission -> /home/yunohost.app/transmission transition
+# Use rm because ynh_secure_remove fails on dangling symlinks, see https://github.com/YunoHost/issues/issues/2253...
+rm "$MEDIA_DIRECTORY/share/Torrents"
+rm "$MEDIA_DIRECTORY/share/Torrent to download"
+
 ynh_multimedia_build_main_dir
 
 # Set rights on transmission directory (parent need to be readable by other, and progress need to be writable by multimedia. Because files will move)


### PR DESCRIPTION
We moved from /home/yunohost.transmission to /home/yunohost.app/transmission. Dangling symlinks might exist in the $MEDIA_DIRECTORY...

Removing this before ynh_multimedia_build_main_dir will fix this, and the symlinks will be recreated after by ynh_multimedia_addfolder.
