### PR TITLE
Add a workaround in Nginx to make RPC work with basic auth, and return 401 instead of 302.

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,8 +1,23 @@
-location __PATH__/transmission {
-  proxy_pass http://127.0.0.1:__PORT____PATH__/transmission;
+location __PATH__/transmission/rpc {
+  proxy_pass http://127.0.0.1:__PORT____PATH__/transmission/rpc;
   more_clear_input_headers 'Accept-Encoding';
 
   client_max_body_size 8M;
+
+  # This is a fix up for RPC login. Client is either a browser
+  # (SSOwAuthUser cookie) or a transmission-remote client (Basic Auth)
+  # If none is present, return a 401.
+  set $rpcauth 0;
+  if ($http_authorization ~ "Basic .*") {
+    set $rpcauth 1;
+  }
+  if ($cookie_SSOwAuthUser != "") {
+    set $rpcauth 1;
+  }
+  if ($rpcauth = 0) {
+    more_set_headers "WWW-Authenticate: Basic";
+    return 401;
+  }
 
   # Include SSOWAT user panel.
   include conf.d/yunohost_panel.conf.inc;


### PR DESCRIPTION
We need to do that *only* on the RPC location to keep redirect to SSO working.

## Problem

RPC does not work because clients do CURLAUTH_ANY

## Solution

Weird trick in nginx.
